### PR TITLE
Add commit history support

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,152 @@
+import { style } from 'kleur-template'
+import { $, hasBinary } from './command'
+import { handle } from './util'
+const { log } = console
+
+/**
+ * Validate if the current directory is a git repository
+ * and that git is installed.
+ */
+async function validate() {
+    if (!hasBinary('git')) {
+        log(style`[Git is not installed](red.bold)`)
+        process.exit(1)
+    }
+
+    // Check if we're in a git repository
+    const gitStatus = await handle($('git status'))
+    if (gitStatus.error) {
+        log(style`[Not in a git repository](red.bold)`)
+        process.exit(1)
+    }
+}
+
+/**
+ * Returns the current branch name. Assumes that the current
+ * directory is a git repository, and that git is installed.
+ */
+async function getCurrentBranch(): Promise<string> {
+    const gitBranch = await handle($('git branch --show-current'))
+    if (gitBranch.error) {
+        log(style`[Error getting current branch](red.bold)`)
+        log(style`[Error: ${gitBranch.error.message}](gray)`)
+        process.exit(1)
+    }
+
+    return gitBranch.data.trim()
+}
+
+interface GitDiff {
+    file: string
+    diff: string
+    tokens: number
+}
+
+async function getUnstagedFiles(branch: string): Promise<GitDiff[]> {
+    // List all the files that have been changed
+    const gitDiff = await handle($(`git diff --name-only ${branch}`))
+    if (gitDiff.error) {
+        log(style`[Error getting git diff](red.bold)`)
+        log(style`[Error: ${gitDiff.error.message}](gray)`)
+        process.exit(1)
+    }
+
+    const files = gitDiff.data.split('\n').filter(Boolean)
+
+    if (files.length === 0) {
+        log(style`[No changes found in the repository](red.bold)`)
+        process.exit(1)
+    }
+
+    const gitDiffFiles = await Promise.all(files.map(async (file) => {
+        const gitDiffFile = await handle($(`git diff ${branch} -- ${file}`))
+        if (gitDiffFile.error) {
+            log(style`[Error getting git diff for ${file}](red.bold)`)
+            log(style`[Error: ${gitDiffFile.error.message}](gray)`)
+            process.exit(1)
+        }
+        return {
+            file,
+            diff: gitDiffFile.data,
+            tokens: gitDiffFile.data.length / 4,
+        }
+    }))
+    return gitDiffFiles.filter(({ tokens }) => tokens > 0 && tokens < 3000)
+}
+
+async function getDiffFromCommitsHistoryFiles(numberOfCommits: number): Promise<GitDiff[]> {
+    const gitCommits = await handle($(`git log -n ${numberOfCommits} --pretty=format:%H`))
+    if (gitCommits.error) {
+        log(style`[Error getting git commits](red.bold)`)
+        log(style`[Error: ${gitCommits.error.message}](gray)`)
+        process.exit(1)
+    }
+
+    const commits = gitCommits.data.split('\n').filter(Boolean)
+
+    const diffFiles = await Promise.all(
+        commits.map(async (commit) => {
+            const gitFiles = await handle($(`git diff ${commit} --name-only`))
+            if (gitFiles.error) {
+                log(style`[Error getting git diff](red.bold)`)
+                log(style`[Error: ${gitFiles.error.message}](gray)`)
+                process.exit(1)
+            }
+
+            const files = gitFiles.data.split('\n').filter(Boolean)
+
+            const gitDiffFiles = await Promise.all(
+                files.map(async (file) => {
+                    const gitDiffFile = await handle($(`git diff ${commit} -- ${file}`))
+                    if (gitDiffFile.error) {
+                        log(style`[Error getting git diff for ${file}](red.bold)`)
+                        log(style`[Error: ${gitDiffFile.error.message}](gray)`)
+                        process.exit(1)
+                    }
+                    const diff = gitDiffFile.data
+                    const tokens = diff.split(/\s+/).length
+                    return {
+                        file,
+                        diff,
+                        tokens,
+                    }
+                }),
+            )
+            return gitDiffFiles.filter(({ tokens }) => tokens > 0 && tokens < 3000)
+        }),
+    )
+
+    const files = diffFiles.flat()
+
+    if (files.length === 0) {
+        log(style`[No changes found in the repository](red.bold)`)
+        process.exit(1)
+    }
+
+    // Merge files with the same name
+    const mergedFiles: GitDiff[] = []
+
+    // We need to verify to check if there is a better way to do this.
+    files.forEach((file) => {
+        const index = mergedFiles.findIndex((f: GitDiff) => f.file === file.file)
+        if (index === -1) {
+            mergedFiles.push(file)
+        }
+        else {
+            mergedFiles[index].diff += file.diff
+            mergedFiles[index].tokens += file.tokens
+        }
+    })
+
+    return mergedFiles
+}
+
+export async function getGitDiff(numberOfCommits?: number) {
+    await validate()
+    const currentBranch = await getCurrentBranch()
+
+    if (numberOfCommits && numberOfCommits > 0)
+        return await getDiffFromCommitsHistoryFiles(numberOfCommits)
+
+    return await getUnstagedFiles(currentBranch)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ async function main() {
     const args = minimist(process.argv.slice(2))
 
     const numberOfCommits = args.last ? parseInt(args.last, 10) : undefined
-    const gitDiffFiles = await getGitDiff((numberOfCommits && numberOfCommits >= 1 && numberOfCommits <= MAX_COMMITS) ? numberOfCommits : undefined)
+    const gitDiffFiles = await getGitDiff((numberOfCommits && numberOfCommits >= 1 && numberOfCommits <= MAX_COMMITS) ? numberOfCommits + 1 : undefined)
 
     const limit = pLimit(10)
     intro('deto')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,73 +1,26 @@
 #!/usr/bin/env node
-import { style } from 'kleur-template'
 import pLimit from 'p-limit'
 import { intro, note, outro, select } from '@clack/prompts'
 import { marked } from 'marked'
 import TerminalRenderer from 'marked-terminal'
 import clipboard from 'clipboardy'
 import minimist from 'minimist'
-import { $, hasBinary } from './command'
-import { handle } from './util'
 import { summarizeDiff, summarizePullRequest } from './api'
 import { createBar } from './progress'
+import { getGitDiff } from './git'
 const { log } = console
 
-async function getGitDiff() {
-    if (!hasBinary('git')) {
-        log(style`[Git is not installed](red.bold)`)
-        process.exit(1)
-    }
-    // Check if we're in a git repository
-    const gitStatus = await handle($('git status'))
-    if (gitStatus.error) {
-        log(style`[Not in a git repository](red.bold)`)
-        process.exit(1)
-    }
-
-    // Check if we're on a branch
-    const gitBranch = await handle($('git branch --show-current'))
-    if (gitBranch.error) {
-        log(style`[Error getting current branch](red.bold)`)
-        log(style`[Error: ${gitBranch.error.message}](gray)`)
-        process.exit(1)
-    }
-
-    const currentBranch = gitBranch.data.trim()
-
-    // List all the files that have been changed
-    const gitDiff = await handle($(`git diff --name-only ${currentBranch}`))
-    if (gitDiff.error) {
-        log(style`[Error getting git diff](red.bold)`)
-        log(style`[Error: ${gitDiff.error.message}](gray)`)
-        process.exit(1)
-    }
-
-    const files = gitDiff.data.split('\n').filter(Boolean)
-    if (files.length === 0) {
-        log(style`[No changes found in the repository](red.bold)`)
-        process.exit(1)
-    }
-
-    // Get the diff for each file
-    const gitDiffFiles = await Promise.all(files.map(async (file) => {
-        const gitDiffFile = await handle($(`git diff ${currentBranch} -- ${file}`))
-        if (gitDiffFile.error) {
-            log(style`[Error getting git diff for ${file}](red.bold)`)
-            log(style`[Error: ${gitDiffFile.error.message}](gray)`)
-            process.exit(1)
-        }
-        return {
-            file,
-            diff: gitDiffFile.data,
-            tokens: gitDiffFile.data.length / 4,
-        }
-    }))
-    return gitDiffFiles.filter(({ tokens }) => tokens > 0 && tokens < 3000)
-}
+/**
+ * The maximum number of commits that can be summarized.
+ */
+const MAX_COMMITS = 10
 
 async function main() {
     const args = minimist(process.argv.slice(2))
-    const gitDiffFiles = await getGitDiff()
+
+    const numberOfCommits = args.last ? parseInt(args.last, 10) : undefined
+    const gitDiffFiles = await getGitDiff((numberOfCommits && numberOfCommits >= 1 && numberOfCommits <= MAX_COMMITS) ? numberOfCommits : undefined)
+
     const limit = pLimit(10)
     intro('deto')
     note(`Summarizing ${gitDiffFiles.length} files.`)


### PR DESCRIPTION
# Summary of Pull Request

## Changes to `src/index.ts`
- `getGitDiff()` function moved to a separate file and imported
- Optional argument added for maximum number of commits to summarize
- Argument parsed from command line using `minimist()`
- Summary now includes note on number of files being summarized

## New File: `git.ts`
- Contains functions to validate if current directory is a git repository, get current branch name, and get unstaged files or diff from commit history files
- `getGitDiff()` function can take optional parameter to get diff from specific number of commits in history
- Output includes error messages for various scenarios such as when git is not installed, when there are no changes found in the repository, or when there is an error getting the git diff.

## Example

```bash
deto --last 3 # number of commits in history to summarize 
```

<img width="1420" alt="deto-screenshot" src="https://github.com/henrycunh/deto/assets/21347264/8f4bccb8-6668-448c-8116-7eee78aea1da">
